### PR TITLE
fixed not persisiting settings within same session

### DIFF
--- a/src/GoogleChartTimeline/widget/GoogleChartTimeline.js
+++ b/src/GoogleChartTimeline/widget/GoogleChartTimeline.js
@@ -338,6 +338,7 @@ define([
         }
         google.visualization.events.addListener(this._chart, 'ready', dojoLang.hitch(this, this._setGraphHeight));
       }
+      this._setChartOptions();
       this._chart.draw(this._dataTable, this._options);
     },
 


### PR DESCRIPTION
After adding some options to this widget (not in this merge, but I can make one if you like), I noticed that the options did not persist, not even in the same session (by changing tabs or screens for example). The options already available like bar_color and background_color did not persist either, and after some digging I found that the options variable returns a null, so only defaults will be used as options. The google defaults I mean.

It probably is only noticed just now, because everything works great at the first load or after a full refresh 🙈 

Anyway, fixed it by calling setChartOptions before each draw fixes this. 